### PR TITLE
fix: copy threshold definitions from grz-cli

### DIFF
--- a/src/grz_pydantic_models/resources/thresholds.json
+++ b/src/grz_pydantic_models/resources/thresholds.json
@@ -1,0 +1,299 @@
+[
+  {
+    "libraryType": "panel",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "panel",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 30,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 20,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "germline-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 30,
+      "readLength": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 30,
+        "fractionBasesAbove": 0.85
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 20,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "panel_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "panel_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 200,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 100,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wes_lr",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs_lr",
+    "sequenceSubtype": "somatic",
+    "genomicStudySubtype": "tumor-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 100,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 30,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs_lr",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "tumor+germline",
+    "thresholds": {
+      "meanDepthOfCoverage": 30,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 20,
+        "fractionAbove": 0.8
+      }
+    }
+  },
+  {
+    "libraryType": "wgs_lr",
+    "sequenceSubtype": "germline",
+    "genomicStudySubtype": "germline-only",
+    "thresholds": {
+      "meanDepthOfCoverage": 30,
+      "fractionBasesAboveQualityThreshold": {
+        "qualityThreshold": 20,
+        "fractionBasesAbove": 0.8
+      },
+      "targetedRegionsAboveMinCoverage": {
+        "minCoverage": 20,
+        "fractionAbove": 0.8
+      }
+    }
+  }
+]

--- a/src/grz_pydantic_models/v1_1_1/metadata.py
+++ b/src/grz_pydantic_models/v1_1_1/metadata.py
@@ -1017,7 +1017,7 @@ type Thresholds = dict[tuple[str, str, str], dict[str, Any]]
 
 def _load_thresholds() -> Thresholds:
     threshold_definitions = json.load(
-        files("grz_cli").joinpath("resources", "thresholds.json").open("r", encoding="utf-8")
+        files("grz_pydantic_models").joinpath("resources", "thresholds.json").open("r", encoding="utf-8")
     )
     threshold_definitions = {
         (d["genomicStudySubtype"], d["libraryType"], d["sequenceSubtype"]): d["thresholds"]


### PR DESCRIPTION
The resource can be dropped from `grz-cli` later, once it pulls in the latest release of `grz_pydantic_models`.