### PR TITLE
docs: remove double entries in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@
 
 ### Features
 
-* make threshold keys consistent with submission metadata ([40d445f](https://github.com/BfArM-MVH/grz-pydantic-models/commit/40d445f61416ee555490322734c70edf70f49836))
 * make threshold keys consistent with submission metadata ([0dafdb6](https://github.com/BfArM-MVH/grz-pydantic-models/commit/0dafdb6228ac64c70aa815eb1b12b68bbf2dd389))
 
 
 ### Documentation
 
-* clarify coverageType values ([1fa49f0](https://github.com/BfArM-MVH/grz-pydantic-models/commit/1fa49f059d9a72201b10cff88a97ac075782fcb4))
 * clarify coverageType values ([c42b43c](https://github.com/BfArM-MVH/grz-pydantic-models/commit/c42b43cede1598c74af56225b31eb219b40c2b4d))


### PR DESCRIPTION
release-please currently has no plans to handle merge commits.

I've blocked merge commits to `main` with a ruleset to prevent this from happening in the future.